### PR TITLE
Regex config

### DIFF
--- a/thumbor_imgix_compat/__init__.py
+++ b/thumbor_imgix_compat/__init__.py
@@ -14,9 +14,6 @@ Config.define('IMGIX_COMPAT_HASH', None, 'Imgix hash', 'ImgixCompat')
 Config.define('IMGIX_COMPAT_STORAGE_ROOT', None, 'Imgix storage root', 'ImgixCompat')
 Config.define('IMGIX_COMPAT_AUTO_QUALITY', 95, 'Quality to use for auto=compress', 'ImgixCompat')
 
-logger.debug("CONFIG")
-logger.debug(Config.get("IMGIX_COMPAT_HASH"))
-
 # Register the route
 for r in ImgxCompatHandler.regex():
     extension.add_handler(r, ImgxCompatHandler)

--- a/thumbor_imgix_compat/__init__.py
+++ b/thumbor_imgix_compat/__init__.py
@@ -14,6 +14,9 @@ Config.define('IMGIX_COMPAT_HASH', None, 'Imgix hash', 'ImgixCompat')
 Config.define('IMGIX_COMPAT_STORAGE_ROOT', None, 'Imgix storage root', 'ImgixCompat')
 Config.define('IMGIX_COMPAT_AUTO_QUALITY', 95, 'Quality to use for auto=compress', 'ImgixCompat')
 
+logger.debug("CONFIG")
+logger.debug(Config.get("IMGIX_COMPAT_HASH"))
+
 # Register the route
 for r in ImgxCompatHandler.regex():
     extension.add_handler(r, ImgxCompatHandler)

--- a/thumbor_imgix_compat/handlers/imgix_compat.py
+++ b/thumbor_imgix_compat/handlers/imgix_compat.py
@@ -8,12 +8,9 @@
 from hashlib import md5
 import tornado.web
 from urllib.parse import urlparse, parse_qs
+from os import getenv
 
 from thumbor.handlers.imaging import ImagingHandler
-from thumbor.utils import logger
-
-from thumbor_imgix_compat.imgix_compat import ImgixCompat
-from tc_core.web import RequestParser
 
 
 class ImgxCompatHandler(ImagingHandler):
@@ -26,11 +23,8 @@ class ImgxCompatHandler(ImagingHandler):
         :return: The list of regex used for routing.
         :rtype: string
         '''
-        return [
-            r'^/listing-assets/.*',
-            r'^/uploads/.*',
-            r'^/.*png$',
-        ]
+        regexp_list = getenv('IMGIX_HANDLER_REGEXP')
+        return regexp_list.split(';')
 
 
     def check_imgix_signature(self, qs: map) -> bool:

--- a/thumbor_imgix_compat/handlers/imgix_compat.py
+++ b/thumbor_imgix_compat/handlers/imgix_compat.py
@@ -104,7 +104,7 @@ class ImgxCompatHandler(ImagingHandler):
             'valign': valign,
             'smart': smart,
             'filters': ':'.join(filters) if len(filters) > 0 else None,
-            'image': self.context.config.get('IMGIX_COMPAT_STORAGE_ROOT') + parsed.path,
+            'image': self.context.config.get('IMGIX_COMPAT_STORAGE_ROOT') + parsed.path.lstrip('/'),
         }
 
 


### PR DESCRIPTION
The thumbor config is not available when the library is loaded, so `IMGIX_HANDLER_REGEXP` is read from the environment.
It should be a semi-colon separated list of regular expressions. If a URL matches any of those expressions, the handler will be used.